### PR TITLE
Fix cassette spool rotation direction

### DIFF
--- a/lib/ui/widgets/cassette.dart
+++ b/lib/ui/widgets/cassette.dart
@@ -20,7 +20,7 @@ class _CassetteState extends State<Cassette>
   bool get _animated => widget.animated;
 
   int get _durationSec => widget.durationSec;
-  final double _rotationRatio = 0.63;
+  final double _rotationRatio = -0.63;
 
   @override
   void initState() {


### PR DESCRIPTION
Small fix so that the rotation animation of the cassette spools matches the direction of a real cassette when playing forwards. :)